### PR TITLE
HW-51305 Create PayPal Account (Client SDK) - iOS (#2)

### DIFF
--- a/HyperwalletSDK.xcodeproj/project.pbxproj
+++ b/HyperwalletSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0733FE092277C191000FB92A /* HyperwalletPayPalAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0733FE082277C191000FB92A /* HyperwalletPayPalAccount.swift */; };
+		0733FE2C2277C7F1000FB92A /* HyperwalletPayPalAccountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0733FE2A2277C743000FB92A /* HyperwalletPayPalAccountTests.swift */; };
+		07C00B032277D25700E0930C /* HyperwalletPayPalAccountPagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C00B022277D25700E0930C /* HyperwalletPayPalAccountPagination.swift */; };
+		07C00B082277D54700E0930C /* PayPalAccountResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = 07C00B062277D30000E0930C /* PayPalAccountResponse.json */; };
+		07C00B0B2277D5DC00E0930C /* PayPalAccountResponseWithMissingEmail.json in Resources */ = {isa = PBXBuildFile; fileRef = 07C00B092277D5CB00E0930C /* PayPalAccountResponseWithMissingEmail.json */; };
+		07C00B522278EE4D00E0930C /* PayPalAccountResponseWithInvalidEmail.json in Resources */ = {isa = PBXBuildFile; fileRef = 07C00B502278EC3500E0930C /* PayPalAccountResponseWithInvalidEmail.json */; };
+		07C00B562278F03600E0930C /* ListPayPalAccountResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = 07C00B542278EFB200E0930C /* ListPayPalAccountResponse.json */; };
+		07C00B59227A120F00E0930C /* PayPalAccountResponseNotProfileEmail.json in Resources */ = {isa = PBXBuildFile; fileRef = 07C00B57227A11CB00E0930C /* PayPalAccountResponseNotProfileEmail.json */; };
 		9807B74522642BEA0028A280 /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9807B74422642BEA0028A280 /* OSLog.swift */; };
 		980C15DB2273BF91004C60D6 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 980C15DA2273BF91004C60D6 /* CHANGELOG.md */; };
 		980C15F12273D1FA004C60D6 /* ListBankCardResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = DBCA37A6225D6D1700CD4137 /* ListBankCardResponse.json */; };
@@ -91,6 +99,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0733FE082277C191000FB92A /* HyperwalletPayPalAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperwalletPayPalAccount.swift; sourceTree = "<group>"; };
+		0733FE2A2277C743000FB92A /* HyperwalletPayPalAccountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperwalletPayPalAccountTests.swift; sourceTree = "<group>"; };
+		07C00B022277D25700E0930C /* HyperwalletPayPalAccountPagination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperwalletPayPalAccountPagination.swift; sourceTree = "<group>"; };
+		07C00B062277D30000E0930C /* PayPalAccountResponse.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PayPalAccountResponse.json; sourceTree = "<group>"; };
+		07C00B092277D5CB00E0930C /* PayPalAccountResponseWithMissingEmail.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PayPalAccountResponseWithMissingEmail.json; sourceTree = "<group>"; };
+		07C00B502278EC3500E0930C /* PayPalAccountResponseWithInvalidEmail.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PayPalAccountResponseWithInvalidEmail.json; sourceTree = "<group>"; };
+		07C00B542278EFB200E0930C /* ListPayPalAccountResponse.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ListPayPalAccountResponse.json; sourceTree = "<group>"; };
+		07C00B57227A11CB00E0930C /* PayPalAccountResponseNotProfileEmail.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PayPalAccountResponseNotProfileEmail.json; sourceTree = "<group>"; };
 		9807B74422642BEA0028A280 /* OSLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OSLog.swift; sourceTree = "<group>"; };
 		980C15DA2273BF91004C60D6 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		98101DBA2238A2F000BA04CA /* HyperwalletSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HyperwalletSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -249,6 +265,7 @@
 				DBCA3770225D6A8D00CD4137 /* HyperwalletBankAccountTests.swift */,
 				DBCA3771225D6A8D00CD4137 /* HyperwalletBankCardTests.swift */,
 				DBCA3772225D6A8D00CD4137 /* HyperwalletErrorTests.swift */,
+				0733FE2A2277C743000FB92A /* HyperwalletPayPalAccountTests.swift */,
 				DBCA376E225D6A8D00CD4137 /* HyperwalletTransferMethodConfigurationTests.swift */,
 				DBCA3773225D6A8D00CD4137 /* HyperwalletTransferMethodTests.swift */,
 				98101DCA2238A2F000BA04CA /* Info.plist */,
@@ -267,6 +284,7 @@
 				DB1A03FB225D3DE40080C8D6 /* HyperwalletBankCard.swift */,
 				DB1A03FA225D3DE40080C8D6 /* HyperwalletStatusTransition.swift */,
 				DB1A03F3225D3DE40080C8D6 /* HyperwalletTransferMethod.swift */,
+				0733FE082277C191000FB92A /* HyperwalletPayPalAccount.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -304,6 +322,7 @@
 				DB1A03F7225D3DE40080C8D6 /* HyperwalletPageList.swift */,
 				DB1A03F8225D3DE40080C8D6 /* HyperwalletBankCardPagination.swift */,
 				DB1A03F9225D3DE40080C8D6 /* HyperwalletBankAccountPagination.swift */,
+				07C00B022277D25700E0930C /* HyperwalletPayPalAccountPagination.swift */,
 			);
 			path = Paging;
 			sourceTree = "<group>";
@@ -343,6 +362,11 @@
 				DBCA37BD225D6E1900CD4137 /* BankCardResponse.json */,
 				DBCA37A2225D6D1600CD4137 /* ListBankAccountResponse.json */,
 				DBCA37A6225D6D1700CD4137 /* ListBankCardResponse.json */,
+				07C00B542278EFB200E0930C /* ListPayPalAccountResponse.json */,
+				07C00B062277D30000E0930C /* PayPalAccountResponse.json */,
+				07C00B57227A11CB00E0930C /* PayPalAccountResponseNotProfileEmail.json */,
+				07C00B502278EC3500E0930C /* PayPalAccountResponseWithInvalidEmail.json */,
+				07C00B092277D5CB00E0930C /* PayPalAccountResponseWithMissingEmail.json */,
 				DBCA37A7225D6D1700CD4137 /* StatusTransitionMockedResponseInvalidTransition.json */,
 				DBCA37A3225D6D1600CD4137 /* StatusTransitionMockedResponseSuccess.json */,
 				DBCA37A8225D6D1700CD4137 /* TransferMethodConfigurationEmptyResponse.json */,
@@ -477,14 +501,19 @@
 				DBCA37BC225D6DD900CD4137 /* BankCardErrorResponseWithMissingCardNumber.json in Resources */,
 				DBCA37B5225D6D1700CD4137 /* TransferMethodConfigurationEmptyResponse.json in Resources */,
 				DBCA37B9225D6D1700CD4137 /* BankCardErrorResponseWithInvalidBranchId.json in Resources */,
+				07C00B0B2277D5DC00E0930C /* PayPalAccountResponseWithMissingEmail.json in Resources */,
+				07C00B59227A120F00E0930C /* PayPalAccountResponseNotProfileEmail.json in Resources */,
+				07C00B082277D54700E0930C /* PayPalAccountResponse.json in Resources */,
 				DBCA37BE225D6E1900CD4137 /* BankCardResponse.json in Resources */,
 				DBCA37BA225D6D1700CD4137 /* TransferMethodConfigurationKeysResponse.json in Resources */,
+				07C00B522278EE4D00E0930C /* PayPalAccountResponseWithInvalidEmail.json in Resources */,
 				DBCA37AF225D6D1700CD4137 /* ListBankAccountResponse.json in Resources */,
 				DBCA37B6225D6D1700CD4137 /* TransferMethodConfigurationFieldsResponse.json in Resources */,
 				DBCA37B8225D6D1700CD4137 /* TransferMethodConfigurationKeysWithoutFeeResponse.json in Resources */,
 				DBCA37B7225D6D1700CD4137 /* BankAccountErrorResponseWithMissingBankId.json in Resources */,
 				DBCA37AE225D6D1700CD4137 /* BankAccountResponse.json in Resources */,
 				DBCA37B2225D6D1700CD4137 /* BankCardErrorResponseWithInvalidCardNumber.json in Resources */,
+				07C00B562278F03600E0930C /* ListPayPalAccountResponse.json in Resources */,
 				DBCA37B1225D6D1700CD4137 /* TransferMethodConfigurationGraphQlResponse.json in Resources */,
 				DBCA37B4225D6D1700CD4137 /* StatusTransitionMockedResponseInvalidTransition.json in Resources */,
 			);
@@ -530,6 +559,7 @@
 				DB1A040A225D3DE40080C8D6 /* HyperwalletPageList.swift in Sources */,
 				DB1A0405225D3DE40080C8D6 /* GraphQlData.swift in Sources */,
 				DB1A0404225D3DE40080C8D6 /* GraphQlError.swift in Sources */,
+				07C00B032277D25700E0930C /* HyperwalletPayPalAccountPagination.swift in Sources */,
 				DB1A03DA225D3DD80080C8D6 /* HyperwalletAuthenticationTokenProvider.swift in Sources */,
 				DB1A040C225D3DE40080C8D6 /* HyperwalletBankAccountPagination.swift in Sources */,
 				DB1A0407225D3DE40080C8D6 /* HyperwalletTransferMethod.swift in Sources */,
@@ -548,6 +578,7 @@
 				DB1A0409225D3DE40080C8D6 /* HyperwalletPagination.swift in Sources */,
 				DB1A0408225D3DE40080C8D6 /* HyperwalletTransferMethodPagination.swift in Sources */,
 				DB1A03FE225D3DE40080C8D6 /* TransferMethodConfiguration.swift in Sources */,
+				0733FE092277C191000FB92A /* HyperwalletPayPalAccount.swift in Sources */,
 				DB1A03D9225D3DD80080C8D6 /* HTTPClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -562,6 +593,7 @@
 				DB1A0417225D4D8B0080C8D6 /* AnyCodableTests.swift in Sources */,
 				DBCA377A225D6A8D00CD4137 /* HyperwalletTransferMethodTests.swift in Sources */,
 				DBCA3777225D6A8D00CD4137 /* HyperwalletBankAccountTests.swift in Sources */,
+				0733FE2C2277C7F1000FB92A /* HyperwalletPayPalAccountTests.swift in Sources */,
 				DB1A0422225D571B0080C8D6 /* AuthenticationTokenGeneratorMock.swift in Sources */,
 				DBCA3775225D6A8D00CD4137 /* HyperwalletTransferMethodConfigurationTests.swift in Sources */,
 				DB1A0414225D4D8B0080C8D6 /* ConfigurationTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hyperwallet iOS Core SDK
 
-Welcome to Hyperwallet's iOS SDK. This library will help you create transfer methods in your iOS app, such as bank account, Paypal account, etc. See our [iOS Integration Guide](https://www.hyperwallet.com/developers/) to get started!
+Welcome to Hyperwallet's iOS SDK. This library will help you create transfer methods in your iOS app, such as bank account, PayPal account, etc. See our [iOS Integration Guide](https://www.hyperwallet.com/developers/) to get started!
 
 Note that this SDK is geared towards those who only require backend data, which means you will have to build your own UI.
 
@@ -226,6 +226,71 @@ Hyperwallet.shared.listBankCards(pagination: bankCardPagination) { (result, erro
     if let bankCards = result?.data {
         for bankCard in bankCards {
             print(bankCard.getField(fieldName: .token) ?? "")
+        }
+    }
+}
+```
+
+### Create PayPal Account
+```swift
+let payPalAccount = HyperwalletPayPalAccount.Builder(transferMethodCountry: "US", transferMethodCurrency: "USD")
+.email("test@paypal.com")
+.build()
+
+Hyperwallet.shared.createPayPalAccount(account: payPalAccount, completion: { (result, error) in
+    // Code to handle successful response or error
+    // In case of successful creation, response (HyperwalletPayPalAccount in this case) will contain information about the user’s PayPal account
+    // In case of failure, error (ErrorType) will contain HyperwalletErrors containing information about what caused the failure of PayPal account creation
+})
+```
+
+### Get PayPal Account
+```swift
+Hyperwallet.shared.getPayPalAccount(transferMethodToken: "123123", completion: { (result, error) in
+    // In case of successful, response (HyperwalletPayPalAccount? in this case) will contain information about the user’s PayPal account or nil if not exist.
+    // In case of failure, error (ErrorType) will contain HyperwalletErrors containing information about what caused the failure 
+})
+```
+
+### Update PayPal Account 
+```swift
+let payPalAccount = HyperwalletPayPalAccount.Builder(token: "trm-12345")
+.email("test@paypal.com")
+.build()
+
+Hyperwallet.shared.updatePayPalAccount(account: payPalAccount, completion: { (result, error) in
+    // Code to handle successful response or error
+    // In case of successful creation, response (HyperwalletPayPalAccount in this case) will contain information about the user’s PayPal account
+    // In case of failure, error (ErrorType) will contain HyperwalletErrors containing information about what caused the failure of PayPal account updating
+})
+```
+
+### Deactivate PayPal Account
+```swift
+Hyperwallet.shared.deactivatePayPalAccount(transferMethodToken: "trm-12345", notes: "deactivate PayPal account", completion: { (result, error) in
+    // Code to handle successful response or error
+    // In case of successful creation, response (HyperwalletStatusTransition in this case) will contain information about the status transition
+    // In case of failure, error (ErrorType) will contain HyperwalletErrors containing information about what caused the failure of PayPal account deactivation
+})
+```
+
+### List PayPal Account
+```swift
+let payPalPagination = HyperwalletPayPalAccountPagination()
+payPalPagination.status = .activated
+payPalPagination.sortBy = .ascendantCreatedOn
+
+Hyperwallet.shared.listPayPalAccount(pagination: payPalPagination) { (result, error) in
+    // In case of failure, error (ErrorType) will contain HyperwalletErrors containing information about what caused the failure 
+    guard error == nil else {
+        print(error?.getHyperwalletErrors()?.errorList?)
+        return
+    }
+    
+    // In case of successful, response (HyperwalletPageList<HyperwalletPayPalAccount>? in this case) will contain information about or nil if not exist.
+    if let payPalAccounts = result?.data {
+        for payPalAccount in payPalAccounts {
+            print(payPalAccount.getField(fieldName: .token) ?? "")
         }
     }
 }

--- a/Sources/Hyperwallet.swift
+++ b/Sources/Hyperwallet.swift
@@ -100,6 +100,27 @@ public final class Hyperwallet {
                                     completionHandler: completion)
     }
 
+    /// Creates a `HyperwalletPayPalAccount` for the User associated with the authentication token returned from
+    /// `HyperwalletAuthenticationTokenProvider.retrieveAuthenticationToken(_ : @escaping CompletionHandler)`.
+    ///
+    /// The `completion: @escaping (HyperwalletPayPalAccount?, HyperwalletErrorType?) -> Void` that is passed in to this
+    /// method invocation will receive the successful response(HyperwalletPayPalAccount) or error(HyperwalletErrorType)
+    /// from processing the request.
+    ///
+    /// This function will request a new authentication token via `HyperwalletAuthenticationTokenProvider`
+    /// if the current one is expired or is about to expire.
+    ///
+    /// - Parameters:
+    ///   - account: the `HyperwalletPayPalAccount` to be created
+    ///   - completion: the callback handler of responses from the Hyperwallet platform
+    public func createPayPalAccount(account: HyperwalletPayPalAccount,
+                                    completion: @escaping (HyperwalletPayPalAccount?, HyperwalletErrorType?) -> Void) {
+        httpTransaction.performRest(httpMethod: .post,
+                                    urlPath: "users/%@/paypal-accounts",
+                                    payload: account,
+                                    completionHandler: completion)
+    }
+
     /// Deactivates the `HyperwalletBankAccount` linked to the transfer method token specified. The
     /// `HyperwalletBankAccount` being deactivated must belong to the User that is associated with the
     /// authentication token returned from
@@ -158,6 +179,35 @@ public final class Hyperwallet {
                                     completionHandler: completion)
     }
 
+    /// Deactivates the `HyperwalletPayPalAccount` linked to the transfer method token specified. The
+    /// `HyperwalletPayPalAccount` being deactivated must belong to the User that is associated with the
+    /// authentication token returned from
+    /// `HyperwalletAuthenticationTokenProvider.retrieveAuthenticationToken(_ : @escaping CompletionHandler)`.
+    ///
+    /// The `completion: @escaping (HyperwalletStatusTransition?, HyperwalletErrorType?) -> Void` that is passed in to
+    /// this method invocation will receive the successful response(HyperwalletStatusTransition) or
+    /// error(HyperwalletErrorType) from processing the request.
+    ///
+    /// This function will request a new authentication token via `HyperwalletAuthenticationTokenProvider`
+    /// if the current one is expired or is about to expire.
+    ///
+    /// - Parameters:
+    ///   - transferMethodToken: the Hyperwallet specific unique identifier for the `HyperwalletPayPalAccount`
+    ///                          being deactivated
+    ///   - notes: a note regarding the status change
+    ///   - completion: the callback handler of responses from the Hyperwallet platform
+    public func deactivatePayPalAccount(transferMethodToken: String,
+                                        notes: String? = nil,
+                                        completion: @escaping (HyperwalletStatusTransition?,
+                                                               HyperwalletErrorType?) -> Void) {
+        let statusTransition = HyperwalletStatusTransition(transition: .deactivated)
+        statusTransition.notes = notes
+        httpTransaction.performRest(httpMethod: .post,
+                                    urlPath: "users/%@/paypal-accounts/\(transferMethodToken)/status-transitions",
+                                    payload: statusTransition,
+                                    completionHandler: completion)
+    }
+
     /// Returns the `HyperwalletBankAccount` linked to the transfer method token specified, or nil if none exists.
     ///
     /// The `completion: @escaping (HyperwalletBankAccount?, HyperwalletErrorType?) -> Void` that is passed in to this
@@ -193,6 +243,24 @@ public final class Hyperwallet {
                             completion: @escaping (HyperwalletBankCard?, HyperwalletErrorType?) -> Void) {
         httpTransaction.performRest(httpMethod: .get,
                                     urlPath: "users/%@/bank-cards/\(transferMethodToken)",
+                                    payload: "",
+                                    completionHandler: completion)
+    }
+
+    /// Returns the `HyperwalletPayPalAccount` linked to the transfer method token specified, or nil if none exists.
+    ///
+    /// The `completion: @escaping (HyperwalletPayPalAccount?, HyperwalletErrorType?) -> Void` that is passed in to this
+    /// method invocation will receive the successful response(HyperwalletPayPalAccount) or error(HyperwalletErrorType)
+    /// from processing the request.
+    ///
+    /// - Parameters:
+    ///   - transferMethodToken: the Hyperwallet specific unique identifier for the `HyperwalletPayPalAccount`
+    ///                          being requested
+    ///   - completion: the callback handler of responses from the Hyperwallet platform
+    public func getPayPalAccount(transferMethodToken: String,
+                                 completion: @escaping (HyperwalletPayPalAccount?, HyperwalletErrorType?) -> Void) {
+        httpTransaction.performRest(httpMethod: .get,
+                                    urlPath: "users/%@/paypal-accounts/\(transferMethodToken)",
                                     payload: "",
                                     completionHandler: completion)
     }
@@ -266,6 +334,42 @@ public final class Hyperwallet {
                                                      HyperwalletErrorType?) -> Void) {
         httpTransaction.performRest(httpMethod: .get,
                                     urlPath: "users/%@/bank-cards",
+                                    payload: "",
+                                    pagination: pagination,
+                                    completionHandler: completion)
+    }
+
+    /// Returns the `HyperwalletPayPalAccount` for the User associated with the authentication token returned from
+    /// `HyperwalletAuthenticationTokenProvider.retrieveAuthenticationToken(_ : @escaping CompletionHandler)`,
+    /// or nil if non exist.
+    ///
+    /// The ordering and filtering of `HyperwalletPayPalAccount` will be based on the criteria specified within the
+    /// `HyperwalletPayPalAccountPagination` object, if it is not nil. Otherwise the default ordering and
+    /// filtering will be applied.
+    ///
+    /// * Offset: 0
+    /// * Limit: 10
+    /// * Created Before: N/A
+    /// * Created After: N/A
+    /// * Status: All
+    /// * Sort By: Created On
+    ///
+    /// The `completion: @escaping (HyperwalletPageList<HyperwalletPayPalAccount>?, HyperwalletErrorType?) -> Void`
+    /// that is passed in to this method invocation will receive the successful
+    /// response(HyperwalletPageList<HyperwalletPayPalAccount>?) or error(HyperwalletErrorType) from processing the
+    /// request.
+    ///
+    /// This function will request a new authentication token via `HyperwalletAuthenticationTokenProvider`
+    /// if the current one is expired or is about to expire.
+    ///
+    /// - Parameters:
+    ///   - pagination: the ordering and filtering criteria
+    ///   - completion: the callback handler of responses from the Hyperwallet platform
+    public func listPayPalAccounts(pagination: HyperwalletPayPalAccountPagination? = nil,
+                                   completion: @escaping (HyperwalletPageList<HyperwalletPayPalAccount>?,
+                                                          HyperwalletErrorType?) -> Void) {
+        httpTransaction.performRest(httpMethod: .get,
+                                    urlPath: "users/%@/paypal-accounts",
                                     payload: "",
                                     pagination: pagination,
                                     completionHandler: completion)
@@ -399,6 +503,31 @@ public final class Hyperwallet {
         let token = account.getField(fieldName: .token) as? String ?? ""
         httpTransaction.performRest(httpMethod: .put,
                                     urlPath: "users/%@/bank-cards/\(token)",
+                                    payload: account,
+                                    completionHandler: completion)
+    }
+
+    /// Updates the `HyperwalletPayPalAccount` for the User associated with the authentication token returned from
+    /// `HyperwalletAuthenticationTokenProvider.retrieveAuthenticationToken(_ : @escaping CompletionHandler)`.
+    ///
+    /// To identify the `HyperwalletPayPalAccount` that is going to be updated, the transfer method token must be
+    /// set as part of the `HyperwalletPayPalAccount` object passed in.
+    ///
+    /// The `completion: @escaping (HyperwalletPayPalAccount?, HyperwalletErrorType?) -> Void` that is passed in to this
+    /// method invocation will receive the successful response(HyperwalletPayPalAccount) or error(HyperwalletErrorType)
+    /// from processing the request.
+    ///
+    /// This function will request a new authentication token via `HyperwalletAuthenticationTokenProvider`
+    /// if the current one is expired or is about to expire.
+    ///
+    /// - Parameters:
+    ///   - account: the `HyperwalletPayPalAccount` to be updated
+    ///   - completion: the callback handler of responses from the Hyperwallet platform
+    public func updatePayPalAccount(account: HyperwalletPayPalAccount,
+                                    completion: @escaping (HyperwalletPayPalAccount?, HyperwalletErrorType?) -> Void) {
+        let token = account.getField(fieldName: .token) as? String ?? ""
+        httpTransaction.performRest(httpMethod: .put,
+                                    urlPath: "users/%@/paypal-accounts/\(token)",
                                     payload: account,
                                     completionHandler: completion)
     }

--- a/Sources/Model/HyperwalletPayPalAccount.swift
+++ b/Sources/Model/HyperwalletPayPalAccount.swift
@@ -1,0 +1,70 @@
+//
+// Copyright 2018 - Present Hyperwallet
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+// and associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import Foundation
+/// Representation of the user's PayPal account
+public final class HyperwalletPayPalAccount: HyperwalletTransferMethod {
+    override private init(data: [String: AnyCodable]) {
+        super.init(data: data)
+    }
+
+    public required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+    }
+
+    /// A helper class to build the `HyperwalletPayPalAccount` instance.
+    public final class Builder {
+        private var storage = [String: AnyCodable]()
+
+        /// Creates a new instance of the `HyperwalletPayPalAccount` based on the required parameter to update
+        /// PayPal account.
+        ///
+        /// - Parameter token: The PayPal account token.
+        public init(token: String) {
+            storage[TransferMethodField.token.rawValue] = AnyCodable(value: token)
+        }
+
+        /// Creates a new instance of the `HyperwalletPayPalAccount` based on the required parameters to create
+        /// PayPal account.
+        ///
+        /// - Parameters:
+        ///   - transferMethodCountry: The PayPal account country.
+        ///   - transferMethodCurrency: The PayPal account currency.
+        public init(transferMethodCountry: String, transferMethodCurrency: String) {
+            storage[TransferMethodField.type.rawValue] = AnyCodable(value: TransferMethodType.payPalAccount.rawValue)
+            storage[TransferMethodField.transferMethodCountry.rawValue] = AnyCodable(value: transferMethodCountry)
+            storage[TransferMethodField.transferMethodCurrency.rawValue] = AnyCodable(value: transferMethodCurrency)
+        }
+
+        /// Sets the email address
+        ///
+        /// - Parameter email: The email address user want to create a PayPal account
+        /// - Returns: a self `HyperwalletPayPalAccount.Builder` instance.
+        public func email(_ email: String) -> Builder {
+            storage[TransferMethodField.email.rawValue] = AnyCodable(value: email)
+            return self
+        }
+
+        /// Builds a new instance of the `HyperwalletPayPalAccount`.
+        ///
+        /// - Returns: a new instance of the `HyperwalletPayPalAccount`.
+        public func build() -> HyperwalletPayPalAccount {
+            return HyperwalletPayPalAccount(data: self.storage)
+        }
+    }
+}

--- a/Sources/Model/HyperwalletTransferMethod.swift
+++ b/Sources/Model/HyperwalletTransferMethod.swift
@@ -64,6 +64,7 @@ public class HyperwalletTransferMethod: Codable {
     /// - cardType: The bank card type.
     /// - cvv: The card security code which is embossed or printed on the card.
     /// - dateOfExpiry: The expiration date for the card (YYYY-MM).
+    /// - email: The email address associated with the PayPal account.
     public enum TransferMethodField: String {
         /// Common transfer method fields
         case createdOn
@@ -107,6 +108,9 @@ public class HyperwalletTransferMethod: Codable {
         case cardType
         case cvv
         case dateOfExpiry
+
+        // PayPal account related fields
+        case email
     }
 
     internal init(data: [String: AnyCodable]) {
@@ -115,11 +119,13 @@ public class HyperwalletTransferMethod: Codable {
 
     /// Representation of the transfer method's type
     ///
-    /// - bankAccount:  When the transfer method is Bank Account
-    /// - bankCard:     When the transfer method is Bank Card
+    /// - bankAccount:   When the transfer method is Bank Account
+    /// - bankCard:      When the transfer method is Bank Card
+    /// - payPalAccount: When the transfer method is PayPal Account
     public enum TransferMethodType: String {
         case bankAccount = "BANK_ACCOUNT"
         case bankCard = "BANK_CARD"
+        case payPalAccount = "PAYPAL_ACCOUNT"
     }
 
     /// Creates a new instance of the `HyperwalletTransferMethod`

--- a/Sources/Model/Paging/HyperwalletPayPalAccountPagination.swift
+++ b/Sources/Model/Paging/HyperwalletPayPalAccountPagination.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2018 - Present Hyperwallet
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+// and associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import Foundation
+
+/// Representation of the PayPal accoun t pagination fields.
+public class HyperwalletPayPalAccountPagination: HyperwalletTransferMethodPagination {
+    /// Builds the `HyperwalletPayPalAccountPagination`'s URL Queries.
+    ///
+    /// - Returns: Returns the URL Query's dictionary.
+    override public func toQuery() -> [String: String] {
+        var query = super.toQuery()
+        query["type"] = "PAYPAL_ACCOUNT"
+        return query
+    }
+}

--- a/Tests/HyperwalletPayPalAccountTests.swift
+++ b/Tests/HyperwalletPayPalAccountTests.swift
@@ -1,0 +1,313 @@
+import Hippolyte
+@testable import HyperwalletSDK
+import XCTest
+
+// swiftlint:disable force_cast
+class HyperwalletPayPalAccountTests: XCTestCase {
+    override func setUp() {
+        Hyperwallet.setup(HyperwalletTestHelper.authenticationProvider)
+    }
+
+    override func tearDown() {
+        if Hippolyte.shared.isStarted {
+            Hippolyte.shared.stop()
+        }
+    }
+
+    func testCreatePayPalAccount_success() {
+        // Given
+        let expectation = self.expectation(description: "Create PayPal account completed")
+        let response = HyperwalletTestHelper.okHTTPResponse(for: "PayPalAccountResponse")
+        let url = String(format: "%@/paypal-accounts", HyperwalletTestHelper.userRestURL)
+        let request = HyperwalletTestHelper.buildPostResquest(baseUrl: url, response)
+        HyperwalletTestHelper.setUpMockServer(request: request)
+
+        var payPalAccountResponse: HyperwalletPayPalAccount?
+        var errorResponse: HyperwalletErrorType?
+
+        // When
+        let payPalAccount = HyperwalletPayPalAccount
+            .Builder(transferMethodCountry: "US", transferMethodCurrency: "USD")
+            .email("test@paypal.com")
+            .build()
+
+        Hyperwallet.shared.createPayPalAccount(account: payPalAccount, completion: { (result, error) in
+            payPalAccountResponse = result
+            errorResponse = error
+            expectation.fulfill()
+        })
+        wait(for: [expectation], timeout: 1)
+
+        // Then
+        XCTAssertNotNil(payPalAccount)
+        XCTAssertNil(errorResponse, "The `errorResponse` should be nil")
+        XCTAssertNotNil(payPalAccountResponse?.getFields())
+        XCTAssertEqual(payPalAccountResponse?.getField(fieldName: .email) as! String, "test@paypal.com")
+    }
+
+    func testCreatePayPalAccount_missingMandatoryField_returnBadRequest() {
+        // Given
+        let expectation = self.expectation(description: "Create PayPal account failed")
+        let response = HyperwalletTestHelper.badRequestHTTPResponse(for: "PayPalAccountResponseWithMissingEmail")
+        let url = String(format: "%@/paypal-accounts", HyperwalletTestHelper.userRestURL)
+        let request = HyperwalletTestHelper.buildPostResquest(baseUrl: url, response)
+        HyperwalletTestHelper.setUpMockServer(request: request)
+
+        var payPalAccountResponse: HyperwalletPayPalAccount?
+        var errorResponse: HyperwalletErrorType?
+
+        // When
+        let payPalAccount = HyperwalletPayPalAccount.Builder(transferMethodCountry: "US",
+                                                             transferMethodCurrency: "USD")
+                                                    .build()
+
+        Hyperwallet.shared.createPayPalAccount(account: payPalAccount, completion: { (result, error) in
+        payPalAccountResponse = result
+        errorResponse = error
+        expectation.fulfill()
+        })
+        wait(for: [expectation], timeout: 1)
+
+        // Then
+        XCTAssertNotNil(errorResponse, "The `errorResponse` should not be nil")
+        XCTAssertNil(payPalAccountResponse)
+        XCTAssertEqual(errorResponse?.getHttpCode(), 400)
+        XCTAssertEqual(errorResponse?.getHyperwalletErrors()?.errorList?.first?.fieldName, "email")
+    }
+
+    func testCreatePayPalAccount_notProfileEmail_returnBadRequest() {
+        // Given
+        let expectation = self.expectation(description: "Create PayPal account failed")
+        let response = HyperwalletTestHelper.badRequestHTTPResponse(for: "PayPalAccountResponseNotProfileEmail")
+        let url = String(format: "%@/paypal-accounts", HyperwalletTestHelper.userRestURL)
+        let request = HyperwalletTestHelper.buildPostResquest(baseUrl: url, response)
+        HyperwalletTestHelper.setUpMockServer(request: request)
+
+        var payPalAccountResponse: HyperwalletPayPalAccount?
+        var errorResponse: HyperwalletErrorType?
+
+        // When
+        let payPalAccount = HyperwalletPayPalAccount.Builder(transferMethodCountry: "US",
+                                                             transferMethodCurrency: "USD")
+                                                    .email("notProfileEmail@paypal.com")
+                                                    .build()
+
+        Hyperwallet.shared.createPayPalAccount(account: payPalAccount, completion: { (result, error) in
+            payPalAccountResponse = result
+            errorResponse = error
+            expectation.fulfill()
+        })
+        wait(for: [expectation], timeout: 1)
+
+        // Then
+        XCTAssertNotNil(errorResponse, "The `errorResponse` should not be nil")
+        XCTAssertNil(payPalAccountResponse)
+        XCTAssertEqual(errorResponse?.getHttpCode(), 400)
+        XCTAssertNil(errorResponse?.getHyperwalletErrors()?.errorList?.first?.fieldName)
+        XCTAssertEqual(errorResponse?.getHyperwalletErrors()?.errorList?.first?.code, "CONSTRAINT_VIOLATIONS")
+    }
+
+    func testGetPayPalAccount_success() {
+        // Given
+        let expectation = self.expectation(description: "Get PayPal account completed")
+        let response = HyperwalletTestHelper.okHTTPResponse(for: "PayPalAccountResponse")
+        let url = String(format: "%@/paypal-accounts/trm-12345", HyperwalletTestHelper.userRestURL)
+        let request = HyperwalletTestHelper.buildGetRequest(baseUrl: url, response)
+        HyperwalletTestHelper.setUpMockServer(request: request)
+
+        var payPalAccountResponse: HyperwalletPayPalAccount?
+        var errorResponse: HyperwalletErrorType?
+
+        // When
+        Hyperwallet.shared.getPayPalAccount(transferMethodToken: "trm-12345", completion: { (result, error) in
+            payPalAccountResponse = result
+            errorResponse = error
+            expectation.fulfill()
+        })
+        wait(for: [expectation], timeout: 1)
+
+        // Then
+        XCTAssertNil(errorResponse, "The `errorResponse` should be nil")
+        XCTAssertNotNil(payPalAccountResponse?.getFields())
+        XCTAssertEqual(payPalAccountResponse?.getField(fieldName: .email) as? String, "test@paypal.com")
+    }
+
+    func testUpdatePayPalAccount_success() {
+        // Given
+        let expectation = self.expectation(description: "Update PayPal account completed")
+        let response = HyperwalletTestHelper.okHTTPResponse(for: "PayPalAccountResponse")
+        let url = String(format: "%@/paypal-accounts/trm-12345", HyperwalletTestHelper.userRestURL)
+        let request = HyperwalletTestHelper.buildPutRequest(baseUrl: url, response)
+        HyperwalletTestHelper.setUpMockServer(request: request)
+
+        var payPalAccountResponse: HyperwalletPayPalAccount?
+        var errorResponse: HyperwalletErrorType?
+
+        // When
+        let payPalAccount = HyperwalletPayPalAccount.Builder(token: "trm-12345").email("test@paypal.com").build()
+
+        Hyperwallet.shared.updatePayPalAccount(account: payPalAccount, completion: { (result, error) in
+            payPalAccountResponse = result
+            errorResponse = error
+            expectation.fulfill()
+        })
+        wait(for: [expectation], timeout: 1)
+
+        // Then
+        XCTAssertNil(errorResponse, "The `errorResponse` should be nil")
+        XCTAssertNotNil(payPalAccountResponse?.getFields())
+        XCTAssertEqual(payPalAccountResponse?.getField(fieldName: .email) as! String, "test@paypal.com")
+    }
+
+    func testUpdatePayPalAccount_invalidEmail() {
+        // Given
+        let expectation = self.expectation(description: "Update PayPal account failed")
+        let response = HyperwalletTestHelper.badRequestHTTPResponse(for: "PayPalAccountResponseWithInvalidEmail")
+        let url = String(format: "%@/paypal-accounts/trm-12345", HyperwalletTestHelper.userRestURL)
+        let request = HyperwalletTestHelper.buildPutRequest(baseUrl: url, response)
+        HyperwalletTestHelper.setUpMockServer(request: request)
+
+        var payPalAccountResponse: HyperwalletPayPalAccount?
+        var errorResponse: HyperwalletErrorType?
+
+        // When
+        let payPalAccount = HyperwalletPayPalAccount.Builder(token: "trm-12345").email("test").build()
+
+        Hyperwallet.shared.updatePayPalAccount(account: payPalAccount, completion: { (result, error) in
+            payPalAccountResponse = result
+            errorResponse = error
+            expectation.fulfill()
+        })
+        wait(for: [expectation], timeout: 1)
+
+        // Then
+        XCTAssertNotNil(errorResponse, "The `errorResponse` should not be nil")
+        XCTAssertNil(payPalAccountResponse, "The payPalAccountResponse should be nil")
+        XCTAssertEqual(errorResponse?.getHttpCode(), 400)
+        XCTAssertEqual(errorResponse?.getHyperwalletErrors()?.errorList?.first?.fieldName, "email")
+        XCTAssertEqual(errorResponse?.getHyperwalletErrors()?.errorList?.first?.code, "INVALID_EMAIL_ADDRESS")
+    }
+
+    func testDeactivatePayPalAccount_success() {
+        // Given
+        let expectation = self.expectation(description: "Deactivate PayPal account completed")
+        let response = HyperwalletTestHelper.okHTTPResponse(for: "StatusTransitionMockedResponseSuccess")
+        let url = String(format: "%@/paypal-accounts/trm-12345/status-transitions", HyperwalletTestHelper.userRestURL)
+        let request = HyperwalletTestHelper.buildPostResquest(baseUrl: url, response)
+        HyperwalletTestHelper.setUpMockServer(request: request)
+
+        var statusTransitionResponse: HyperwalletStatusTransition?
+        var errorResponse: HyperwalletErrorType?
+
+        // When
+        Hyperwallet.shared.deactivatePayPalAccount(transferMethodToken: "trm-12345",
+                                                   notes: "deactivate PayPal account",
+                                                   completion: { (result, error) in
+                                                    statusTransitionResponse = result
+                                                    errorResponse = error
+                                                    expectation.fulfill()
+        })
+        wait(for: [expectation], timeout: 1)
+
+        // Then
+        XCTAssertNil(errorResponse, "The `errorResponse` should be nil")
+        XCTAssertNotNil(statusTransitionResponse)
+        XCTAssertEqual(statusTransitionResponse?.transition, HyperwalletStatusTransition.Status.deactivated)
+    }
+
+    func testDeactivatePayPalAccount_invalidTransition() {
+        // Given
+        let expectation = self.expectation(description: "Deactivate PayPal account failed")
+        let response = HyperwalletTestHelper
+            .badRequestHTTPResponse(for: "StatusTransitionMockedResponseInvalidTransition")
+        let url = String(format: "%@/paypal-accounts/trm-12345/status-transitions", HyperwalletTestHelper.userRestURL)
+        let request = HyperwalletTestHelper.buildPostResquest(baseUrl: url, response)
+        HyperwalletTestHelper.setUpMockServer(request: request)
+
+        var statusTransitionResponse: HyperwalletStatusTransition?
+        var errorResponse: HyperwalletErrorType?
+
+        // When
+        Hyperwallet.shared.deactivatePayPalAccount(transferMethodToken: "trm-12345",
+                                                   notes: "deactivate PayPal account",
+                                                   completion: { (result, error) in
+                                                    statusTransitionResponse = result
+                                                    errorResponse = error
+                                                    expectation.fulfill()
+        })
+        wait(for: [expectation], timeout: 1)
+
+        // Then
+        XCTAssertNotNil(errorResponse, "The `errorResponse` should not be nil")
+        XCTAssertNil(statusTransitionResponse, "The statusTransitionResponse should be nil")
+        XCTAssertEqual(errorResponse?.getHttpCode(), 400)
+        XCTAssertEqual(errorResponse?.getHyperwalletErrors()?.errorList?.first?.code, "INVALID_FIELD_VALUE")
+    }
+
+    func testListPayPalAccounts_success() {
+        // Given
+        let expectation = self.expectation(description: "List PayPal account completed")
+        let response = HyperwalletTestHelper.okHTTPResponse(for: "ListPayPalAccountResponse")
+        let url = String(format: "%@/paypal-accounts?+", HyperwalletTestHelper.userRestURL)
+        let request = HyperwalletTestHelper.buildGetRequestRegexMatcher(pattern: url, response)
+        HyperwalletTestHelper.setUpMockServer(request: request)
+
+        var payPalAccountList: HyperwalletPageList<HyperwalletPayPalAccount>?
+        var errorResponse: HyperwalletErrorType?
+
+        // When
+        let payPalAccountPagination = HyperwalletPayPalAccountPagination()
+        payPalAccountPagination.status = .activated
+        payPalAccountPagination.createdAfter = HyperwalletPayPalAccountPagination
+                                                .iso8601
+                                                .date(from: "2018-12-15T00:30:11")
+
+        Hyperwallet.shared.listPayPalAccounts(pagination: payPalAccountPagination) { (result, error) in
+            payPalAccountList = result
+            errorResponse = error
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+
+        // Then
+        XCTAssertNil(errorResponse, "The `errorResponse` should be nil")
+        XCTAssertNotNil(payPalAccountList, "The `payPalAccountList` should not be nil")
+        XCTAssertEqual(payPalAccountList?.count, 1, "The `count` should be 1")
+        XCTAssertNotNil(payPalAccountList?.data, "The `data` should be not nil")
+
+        XCTAssertNotNil(payPalAccountList?.links, "The `links` should be not nil")
+        XCTAssertNotNil(payPalAccountList?.links.first?.params.rel)
+
+        let payPalAccount = payPalAccountList?.data.first
+        XCTAssertEqual(payPalAccount?.getField(fieldName: .token) as? String, "trm-123456789")
+        XCTAssertEqual(payPalAccount?.getField(fieldName: .email) as? String, "test@paypal.com")
+    }
+
+    func testListPayPalAccounts_emptyResult() {
+        // Given
+        let expectation = self.expectation(description: "List PayPal account completed")
+        let response = HyperwalletTestHelper.noContentHTTPResponse()
+        let url = String(format: "%@/paypal-accounts?+", HyperwalletTestHelper.userRestURL)
+        let request = HyperwalletTestHelper.buildGetRequestRegexMatcher(pattern: url, response)
+        HyperwalletTestHelper.setUpMockServer(request: request)
+
+        var payPalAccountList: HyperwalletPageList<HyperwalletPayPalAccount>?
+        var errorResponse: HyperwalletErrorType?
+
+        // When
+        let payPalAccountPagination = HyperwalletPayPalAccountPagination()
+        payPalAccountPagination.status = .deActivated
+
+        // When
+        Hyperwallet.shared.listPayPalAccounts(pagination: payPalAccountPagination) { (result, error) in
+            payPalAccountList = result
+            errorResponse = error
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+
+        // Then
+        XCTAssertNil(errorResponse, "The `errorResponse` should be nil")
+        XCTAssertNil(payPalAccountList, "The `payPalAccountList` should be nil")
+    }
+}

--- a/Tests/Responses/ListPayPalAccountResponse.json
+++ b/Tests/Responses/ListPayPalAccountResponse.json
@@ -1,0 +1,32 @@
+{
+    "count": 1,
+    "offset": 0,
+    "limit": 10,
+    "data": [
+        {
+            "token": "trm-123456789",
+            "type": "PAYPAL_ACCOUNT",
+            "status": "ACTIVATED",
+            "createdOn": "2019-04-30T18:20:44",
+            "transferMethodCountry": "US",
+            "transferMethodCurrency": "USD",
+            "email": "test@paypal.com",
+            "links": [
+                {
+                    "params": {
+                        "rel": "self"
+                    },
+                    "href": "https://localhost/rest/v3/users/usr-123456789/paypal-accounts/trm-123456789"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "params": {
+                "rel": "self"
+            },
+            "href": "https://localhost/rest/v3/users/usr-123456789/paypal-accounts?offset=0&limit=10"
+        }
+    ]
+}

--- a/Tests/Responses/PayPalAccountResponse.json
+++ b/Tests/Responses/PayPalAccountResponse.json
@@ -1,0 +1,17 @@
+{
+    "token": "trm-123456789",
+    "type": "PAYPAL_ACCOUNT",
+    "status": "ACTIVATED",
+    "createdOn": "2019-01-09T22:50:14",
+    "transferMethodCountry": "US",
+    "transferMethodCurrency": "USD",
+    "email": "test@paypal.com",
+    "links": [
+        {
+            "params": {
+                "rel": "self"
+            },
+            "href": "https://localhost/rest/v3/users/usr-123456789/paypal-accounts/trm-123456789"
+        }
+    ]
+}

--- a/Tests/Responses/PayPalAccountResponseNotProfileEmail.json
+++ b/Tests/Responses/PayPalAccountResponseNotProfileEmail.json
@@ -1,0 +1,8 @@
+ {
+    "errors": [
+        {
+            "message": "PayPal transfer method email address should be same as profile email address.",
+            "code": "CONSTRAINT_VIOLATIONS"
+        }
+    ]
+ }

--- a/Tests/Responses/PayPalAccountResponseWithInvalidEmail.json
+++ b/Tests/Responses/PayPalAccountResponseWithInvalidEmail.json
@@ -1,0 +1,9 @@
+{
+    "errors": [
+        {
+            "message": "Email is invalid",
+            "fieldName": "email",
+            "code": "INVALID_EMAIL_ADDRESS"
+        }
+    ]
+}

--- a/Tests/Responses/PayPalAccountResponseWithMissingEmail.json
+++ b/Tests/Responses/PayPalAccountResponseWithMissingEmail.json
@@ -1,0 +1,9 @@
+{
+    "errors": [
+        {
+            "message": "You have left the email field empty",
+            "fieldName": "email",
+            "code": "MISSING_FIELD"
+        }
+    ]
+}

--- a/Tests/TransferMethodConfigurationResultTests.swift
+++ b/Tests/TransferMethodConfigurationResultTests.swift
@@ -94,9 +94,9 @@ class TransferMethodConfigurationResultTests: XCTestCase {
             XCTFail("The PAPER_CHECK has not been found")
         }
 
-        let transferMethodFilterByPaypalAccount = transferMethodTypes.filter { $0 == "PAYPAL_ACCOUNT" }
-        if let paypalAccount = transferMethodFilterByPaypalAccount.first {
-            XCTAssertEqual(paypalAccount, "PAYPAL_ACCOUNT", "Invalid transferMethod")
+        let transferMethodFilterByPayPalAccount = transferMethodTypes.filter { $0 == "PAYPAL_ACCOUNT" }
+        if let payPalAccount = transferMethodFilterByPayPalAccount.first {
+            XCTAssertEqual(payPalAccount, "PAYPAL_ACCOUNT", "Invalid transferMethod")
         } else {
             XCTFail("The PAYPAL_ACCOUNT has not been found")
         }


### PR DESCRIPTION
* HW-51305 Create PayPal Account (Client SDK) - iOS
1. Implemented create/update/deactivate/list Paypal account.
2. Added tests coverage for the new implementaion

* Project should not be runnable

* Changed Paypal -> PayPal

* more renaming

* more renaming

* Fixed some typos

* Update README.md

Added PayPal Implementation to README.md

* Update README.md

Minor changes