### PR TITLE
DTSERWONE-821 Address swiftling v0.50 violations

### DIFF
--- a/Tests/Balance/HyperwalletBalanceTests.swift
+++ b/Tests/Balance/HyperwalletBalanceTests.swift
@@ -93,16 +93,6 @@ class HyperwalletBalanceTests: XCTestCase {
         }
     }
 
-    override static var defaultTestSuite: XCTestSuite {
-        let testSuite = XCTestSuite(name: String(describing: self))
-        let testParameters = getTestParameters()
-
-        for testCaseParameters in testParameters {
-            addTest(with: testCaseParameters, toTestSuite: testSuite)
-        }
-        return testSuite
-    }
-
     private static func addTest(with testCaseParameters: [String?],
                                 toTestSuite testSuite: XCTestSuite) {
         testInvocations.forEach { invocation in

--- a/Tests/Balance/HyperwalletPrepaidCardBalanceTests.swift
+++ b/Tests/Balance/HyperwalletPrepaidCardBalanceTests.swift
@@ -94,16 +94,6 @@ class HyperwalletPrepaidCardBalanceTests: XCTestCase {
         }
     }
 
-    override static var defaultTestSuite: XCTestSuite {
-        let testSuite = XCTestSuite(name: String(describing: self))
-        let testParameters = getTestParameters()
-
-        for testCaseParameters in testParameters {
-            addTest(with: testCaseParameters, toTestSuite: testSuite)
-        }
-        return testSuite
-    }
-
     private static func addTest(with testCaseParameters: [String?],
                                 toTestSuite testSuite: XCTestSuite) {
         testInvocations.forEach { invocation in


### PR DESCRIPTION
## Changes
- Address the swift lint violations from v0.50

```
[
  {
    "character" : 14,
    "file" : "\/Users\/grmeyer\/IntellijWorkspace\/hyperwallet-ios-sdk\/Tests\/Balance\/HyperwalletBalanceTests.swift",
    "line" : 96,
    "reason" : "Empty XCTest method should be avoided.",
    "rule_id" : "empty_xctest_method",
    "severity" : "Error",
    "type" : "Empty XCTest Method"
  },
  {
    "character" : 14,
    "file" : "\/Users\/grmeyer\/IntellijWorkspace\/hyperwallet-ios-sdk\/Tests\/Balance\/HyperwalletPrepaidCardBalanceTests.swift",
    "line" : 97,
    "reason" : "Empty XCTest method should be avoided.",
    "rule_id" : "empty_xctest_method",
    "severity" : "Error",
    "type" : "Empty XCTest Method"
  }
]
Done linting! Found 2 violations, 2 serious in 79 files.
```