### PR TITLE
DTSERWONE-2005 Fix Jazz dependency 

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
+          - os: macos-12
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,9 +16,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      
       - name: Install Jazz
         run: gem install jazzy
-        
+      
       - name: Generate documentation
         run: |
           jazzy \

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,11 +12,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-12
+          - os: macos-13
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-
+      - name: Install Jazz
+        run: gem install jazzy
+        
       - name: Generate documentation
         run: |
           jazzy \


### PR DESCRIPTION
The `macos-13` doesn't support the `jazz`

## Solution: 
- Install Jazz

## Test: 
- Run manually the new yml file
https://github.com/hyperwallet/hyperwallet-ios-sdk/actions/runs/8060210048/job/22015850971
![Screenshot 2024-02-26 at 10 16 15 PM](https://github.com/hyperwallet/hyperwallet-ios-sdk/assets/107439697/6e855bb0-87f3-437e-bba2-4a73409cc114)
